### PR TITLE
S103: maximumlinelength

### DIFF
--- a/src/main/java/lang/maximumlinelenght.yaml
+++ b/src/main/java/lang/maximumlinelenght.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: maximumLineLength
+    patterns:
+      - pattern-regex: .{120,}
+      - pattern-not-regex: //.*|("(?:\\[^"]|\\"|.)*?")|(?s)/\*.*?\*/
+    message: Split this long line which is longer than the 120 character authorised.
+    languages:
+      - java
+    severity: INFO
+    metadata:
+      key: S103
+      github-ref: https://github.com/SonarSource/sonar-java/blob/master/java-checks/src/main/java/org/sonar/java/checks/TooLongLineCheck.java

--- a/src/main/java/lang/maximumlinelength.java
+++ b/src/main/java/lang/maximumlinelength.java
@@ -1,0 +1,14 @@
+package lang.TooLongLine_S103_Check;
+
+import checks.TooLongLine_S103_Check.
+// ruleid: maximumLineLength
+        very_very_very.big.very_very_very.big.very_very_very.big.very_very_very.big.very_very_very.VeryBig;
+
+; // is an EmptyStatementTree that can be part of CompilationUnitTree.imports() as an ImportClauseTree
+
+class LineLength {
+    void method() {
+        // Noncompliant {{Split this 97 characters long line (which is greater than 40 authorized).}}
+        // Noncompliant {{Split this 97 characters long line (which is greater than 40 authorized).}}
+    }
+}


### PR DESCRIPTION
Adds rule S103:
Split this long line which is longer than the 120 character authorised.
